### PR TITLE
Add connection monitoring

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -98,7 +98,7 @@ Pool.prototype.connect = function()
         });
     });
 
-    this.monitorInterval = setInterval(this.monitorConnections.bind(this), 10000);
+    this.monitorInterval = setInterval(this.monitorConnections.bind(this), 15000);
     return deferred.promise;
 };
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -22,210 +22,215 @@ var Pool = module.exports = function Pool(options)
         return sourceValue == null ? destinationValue : sourceValue;
     });
 };
-
 util.inherits(Pool, EventEmitter);
 
 Pool.prototype.TTL = Connection.TTL;
 
-_.extend(Pool.prototype,
+Pool.prototype.hostPoolSize     = 1;
+Pool.prototype.closing          = false;
+Pool.prototype.consistencylevel = 1;
+
+Pool.prototype.hosts            = null;
+Pool.prototype.clients          = null;
+Pool.prototype.dead             = null;
+Pool.prototype.timeout          = null;
+Pool.prototype.retryInterval    = null;
+
+Pool.prototype.keyspace         = null;
+Pool.prototype.cqlVersion       = null;
+Pool.prototype.user             = null;
+Pool.prototype.password         = null;
+
+
+Pool.prototype.getHost = function(clients)
 {
-    'hostPoolSize': 1,
-    'closing': false,
-    'consistencylevel': 1,
+    return clients[Math.floor(Math.random() * clients.length)];
+};
 
-    'hosts': null,
-    'clients': null,
-    'dead': null,
-    'timeout': null,
-    'retryInterval': null,
+Pool.prototype.createConnection = function(host)
+{
+    var options = _.pick(this, 'keyspace', 'user', 'password', 'timeout', 'cqlVersion', 'consistencylevel');
+    options.host = host;
+    options.TTL = this.TTL + Math.floor(Math.random() * 10000);
+    var connection = new Connection(options);
+    connection.on('error', _.bind(this.emit, this, 'error'));
+    return connection;
+};
 
-    'keyspace': null,
-    'cqlVersion': null,
+Pool.prototype.connect = function()
+{
+    var deferred = P.defer(),
+        self = this;
+    var hosts = this.hosts,
+        poolSize = this.hostPoolSize,
+        pendingCount = hosts.length * poolSize;
 
-    'user': null,
-    'password': null,
-
-    'getHost': function getHost(clients)
+    function handleSettle(isResolved, value)
     {
-        return clients[Math.floor(Math.random() * clients.length)];
-    },
-
-    'createConnection': function createConnection(host)
-    {
-        var options = _.pick(this, 'keyspace', 'user', 'password', 'timeout', 'cqlVersion', 'consistencylevel');
-        options.host = host;
-        options.TTL = this.TTL + Math.floor(Math.random() * 10000);
-        var connection = new Connection(options);
-        connection.on('error', _.bind(this.emit, this, 'error'));
-        return connection;
-    },
-
-    'connect': function connect()
-    {
-        var deferred = P.defer(),
-            self = this;
-        var hosts = this.hosts,
-            poolSize = this.hostPoolSize,
-            pendingCount = hosts.length * poolSize;
-
-        function handleSettle(isResolved, value)
+        pendingCount--;
+        if (isResolved)
+            deferred.resolve(value);
+        if (!pendingCount)
         {
-            pendingCount--;
-            if (isResolved)
-                deferred.resolve(value);
-            if (!pendingCount)
-            {
-                deferred.reject(errors.create({ 'name': 'NoAvailableNodesException', 'why': 'Could Not Connect To Any Nodes' }));
-                self.monitorConnections();
-            }
+            deferred.reject(errors.create({ 'name': 'NoAvailableNodesException', 'why': 'Could Not Connect To Any Nodes' }));
+            self.monitorConnections();
         }
+    }
 
-        _.forEach(hosts, function (host)
-        {
-            _.times(poolSize, function ()
-            {
-                var connection = self.createConnection(host);
-                connection.connect().then(function (keyspace)
-                {
-                    handleSettle(true, keyspace);
-                    if (keyspace)
-                        keyspace.connection = self;
-                    self.clients.push(connection);
-                    if (self.closing)
-                        connection.close();
-                }, function (error)
-                {
-                    handleSettle(false);
-                    self.dead.push(host);
-                });
-            });
-        });
-
-        return deferred.promise;
-    },
-
-    'use': function use(keyspace)
+    _.forEach(hosts, function (host)
     {
-        var self = this;
-        return P.allSettled(_.map(this.clients, function (client)
+        _.times(poolSize, function ()
         {
-            return client.use(keyspace).then(function (keyspace)
+            var connection = self.createConnection(host);
+            connection.connect().then(function (keyspace)
             {
+                handleSettle(true, keyspace);
                 if (keyspace)
                     keyspace.connection = self;
-                return keyspace;
-            });
-        }));
-    },
-
-    'assignKeyspace': function assignKeyspace(keyspace)
-    {
-        var self = this;
-
-        return this.use(keyspace)
-        .then(function(promises)
-        {
-            var rejection = _.find(promises, function(promise) { return promise.state == 'rejected' && promise.reason.name == 'ScamandriosNotFoundException'; });
-            if (!rejection)
-                return promises;
-
-            return self.createKeyspace(keyspace)
-            .then(function() { return self.use(keyspace); })
-            .then(function(responses)
+                self.clients.push(connection);
+                if (self.closing)
+                    connection.close();
+            }, function (error)
             {
-                var fulfillment = _.find(responses, { 'state': 'fulfilled' });
-                if (!fulfillment)
-                {
-                    var selectError = new Error('Failed to create and select keyspace.');
-                    _.assign(selectError, { 'keyspace': keyspace, 'responses': responses });
-                    throw selectError;
-                }
-
-                return responses;
+                handleSettle(false);
+                self.dead.push(host);
             });
         });
-    },
+    });
 
-    'getConnection': function getConnection(getHost)
+    return deferred.promise;
+};
+
+Pool.prototype.use = function(keyspace)
+{
+    var self = this;
+    return P.allSettled(_.map(this.clients, function (client)
     {
-        var host = (_.isFunction(getHost) ? getHost : this.getHost).call(this, this.clients);
-        if (!host)
+        return client.use(keyspace).then(function (keyspace)
         {
-            this.emit('error', errors.create({ 'name': 'NoAvailableNodesException', 'why': 'No Available Connections' }));
-            return;
-        }
-        if (host.ready)
-            return host;
-        var clients = this.clients;
-        for (var length = clients.length; length--;)
-        {
-            var client = clients[length];
-            if (!client.ready)
-            {
-                clients.splice(length, 1);
-                this.dead.push(client.host + ':' + client.port);
-            }
-        }
-        return this.getConnection(getHost);
-    },
-
-    'monitorConnections': function monitorConnections()
-    {
-        var self = this;
-        if (this.closing)
-            return;
-
-        function checkDead()
-        {
-            if (self.closing)
-                return;
-            var dead = self.dead;
-            if (dead.length)
-            {
-                var host = dead.pop(),
-                    connection = self.createConnection(host);
-                return connection.connect().then(function ()
-                {
-                    self.clients.push(connection);
-                }, function ()
-                {
-                    dead.push(host);
-                    checkDead();
-                });
-            }
-            self.retryInterval = setTimeout(checkDead, 5000);
-        }
-        this.retryInterval = setTimeout(checkDead, 5000);
-    },
-
-    'close': function close()
-    {
-        var clients = this.clients,
-            pendingClients = clients.length,
-            self = this;
-
-        this.closing = true;
-        clearTimeout(this.retryInterval);
-
-        if (!pendingClients)
-        {
-            this.emit('close');
-            return;
-        }
-
-        function onClose()
-        {
-            pendingClients--;
-            if (!pendingClients)
-                self.emit('close');
-        }
-
-        _.forEach(clients, function (client)
-        {
-            client.on('close', onClose).close();
+            if (keyspace)
+                keyspace.connection = self;
+            return keyspace;
         });
+    }));
+};
+
+Pool.prototype.assignKeyspace = function(keyspace)
+{
+    var self = this;
+
+    return this.use(keyspace)
+    .then(function(promises)
+    {
+        var rejection = _.find(promises, function(promise) { return promise.state == 'rejected' && promise.reason.name == 'ScamandriosNotFoundException'; });
+        if (!rejection)
+            return promises;
+
+        return self.createKeyspace(keyspace)
+        .then(function() { return self.use(keyspace); })
+        .then(function(responses)
+        {
+            var fulfillment = _.find(responses, { 'state': 'fulfilled' });
+            if (!fulfillment)
+            {
+                var selectError = new Error('Failed to create and select keyspace.');
+                _.assign(selectError, { 'keyspace': keyspace, 'responses': responses });
+                throw selectError;
+            }
+
+            return responses;
+        });
+    });
+};
+
+Pool.prototype.getConnection = function(getHost)
+{
+    var host = (_.isFunction(getHost) ? getHost : this.getHost).call(this, this.clients);
+    if (!host)
+    {
+        this.emit('error', errors.create({ 'name': 'NoAvailableNodesException', 'why': 'No Available Connections' }));
+        return;
     }
-});
+    if (host.ready)
+        return host;
+    var clients = this.clients;
+    for (var length = clients.length; length--;)
+    {
+        var client = clients[length];
+        if (!client.ready)
+        {
+            clients.splice(length, 1);
+            var deadhost = client.host + ':' + client.port;
+            this.emit('log', 'pushing host onto dead pool: ' + deadhost);
+            this.dead.push(deadhost);
+        }
+    }
+    return this.getConnection(getHost);
+};
+
+// If a node is alive in any useful sense, it will respond to this query.
+// Nodes that time out or give bogus responses to this should go onto the
+// dead list.
+Pool.PING_QUERY = 'SELECT * FROM system.schema_keyspaces;';
+
+Pool.prototype.monitorConnections = function()
+{
+    var self = this;
+    if (this.closing)
+        return;
+
+    function checkDead()
+    {
+        if (self.closing)
+            return;
+        var dead = self.dead;
+        if (dead.length)
+        {
+            var host = dead.pop(),
+                connection = self.createConnection(host);
+            return connection.connect().then(function ()
+            {
+                self.clients.push(connection);
+            }, function ()
+            {
+                self.emit('log', 'adding host to dead pool: ' + JSON.stringify(host));
+                dead.push(host);
+                checkDead();
+            });
+        }
+        self.retryInterval = setTimeout(checkDead, 5000);
+    }
+
+    this.retryInterval = setTimeout(checkDead, 5000);
+};
+
+Pool.prototype.close = function()
+{
+    var clients = this.clients,
+        pendingClients = clients.length,
+        self = this;
+
+    this.closing = true;
+    clearTimeout(this.retryInterval);
+
+    if (!pendingClients)
+    {
+        this.emit('close');
+        return;
+    }
+
+    function onClose()
+    {
+        pendingClients--;
+        if (!pendingClients)
+            self.emit('close');
+    }
+
+    _.forEach(clients, function (client)
+    {
+        client.on('close', onClose).close();
+    });
+};
 
 _.each(['execute', 'executeCQL', 'cql', 'createKeyspace', 'dropKeyspace'], function (name)
 {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -34,7 +34,6 @@ Pool.prototype.hosts            = null;
 Pool.prototype.clients          = null;
 Pool.prototype.dead             = null;
 Pool.prototype.timeout          = null;
-Pool.prototype.checkDeadTimer = null;
 Pool.prototype.monitorInterval     = null;
 
 Pool.prototype.keyspace         = null;
@@ -74,7 +73,6 @@ Pool.prototype.connect = function()
         if (!pendingCount)
         {
             deferred.reject(errors.create({ 'name': 'NoAvailableNodesException', 'why': 'Could Not Connect To Any Nodes' }));
-            self.monitorConnections();
         }
     }
 
@@ -88,6 +86,7 @@ Pool.prototype.connect = function()
                 handleSettle(true, keyspace);
                 if (keyspace)
                     keyspace.connection = self;
+                self.emit('log', 'connection established to cassandra@' + host);
                 self.clients.push(connection);
                 if (self.closing)
                     connection.close();
@@ -99,7 +98,7 @@ Pool.prototype.connect = function()
         });
     });
 
-    this.monitorInterval = setInterval(this.monitorConnections.bind(this));
+    this.monitorInterval = setInterval(this.monitorConnections.bind(this), 10000);
     return deferred.promise;
 };
 
@@ -163,7 +162,7 @@ Pool.prototype.getConnection = function(getHost)
         {
             clients.splice(length, 1);
             var deadhost = client.host + ':' + client.port;
-            this.emit('log', 'pushing host onto dead pool: ' + deadhost);
+            this.emit('log', 'getConnection() pushing host onto dead pool: ' + deadhost);
             this.dead.push(deadhost);
         }
     }
@@ -191,19 +190,17 @@ Pool.prototype.monitorConnections = function()
             var host = dead.pop(),
                 connection = self.createConnection(host);
             return connection.connect()
-            .then(function ()
+            .then(function()
             {
-                self.emit('log', 'host rising from the dead: ' + host);
+                self.emit('log', 'cassandra host rising from the dead: ' + host);
                 self.clients.push(connection);
             })
-            .fail(function ()
+            .fail(function()
             {
-                self.emit('log', 'host still dead: ' + host);
+                self.emit('log', 'cassandra host still dead: ' + host);
                 dead.push(host);
-                checkDead();
             }).done();
         }
-        self.checkDeadTimer = setTimeout(checkDead, 5000);
     }
 
     function ping(client)
@@ -213,27 +210,30 @@ Pool.prototype.monitorConnections = function()
         function addToDeadPool()
         {
             var deadhost = client.host + ':' + client.port;
-            self.emit('log', 'pushing host onto dead pool: ' + deadhost);
+            self.emit('log', 'ping timeout to cassandra@' + deadhost);
             self.dead.push(deadhost);
-            if (!self.checkDeadTimer)
-                self.checkDeadTimer = setTimeout(checkDead, 5000);
+            client.ready = false;
         }
 
         client.executeCQL(Pool.PING_QUERY)
         .then(function(result)
         {
             clearTimeout(timeout);
+            // self.emit('log', 'good ping to cassandra@' + client.host + ':' + client.port);
         })
         .fail(function(error)
         {
+            self.emit('log', 'connection error to cassandra@' + client.host + ':' + client.port + ' ' + JSON.stringify(error));
             clearTimeout(timeout);
             addToDeadPool();
         }).done();
+
+        timeout = setTimeout(addToDeadPool, 7500);
     }
 
     _.each(self.clients, ping);
     if (self.dead.length)
-        this.checkDeadTimer = setTimeout(checkDead, 5000);
+        checkDead();
 };
 
 Pool.prototype.close = function()
@@ -243,7 +243,6 @@ Pool.prototype.close = function()
         self = this;
 
     this.closing = true;
-    clearTimeout(this.checkDeadTimer);
     clearInterval(this.monitorInterval);
 
     if (!pendingClients)

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -34,7 +34,8 @@ Pool.prototype.hosts            = null;
 Pool.prototype.clients          = null;
 Pool.prototype.dead             = null;
 Pool.prototype.timeout          = null;
-Pool.prototype.retryInterval    = null;
+Pool.prototype.checkDeadTimer = null;
+Pool.prototype.monitorInterval     = null;
 
 Pool.prototype.keyspace         = null;
 Pool.prototype.cqlVersion       = null;
@@ -98,6 +99,7 @@ Pool.prototype.connect = function()
         });
     });
 
+    this.monitorInterval = setInterval(this.monitorConnections.bind(this));
     return deferred.promise;
 };
 
@@ -171,7 +173,7 @@ Pool.prototype.getConnection = function(getHost)
 // If a node is alive in any useful sense, it will respond to this query.
 // Nodes that time out or give bogus responses to this should go onto the
 // dead list.
-Pool.PING_QUERY = 'SELECT * FROM system.schema_keyspaces;';
+Pool.PING_QUERY = new Buffer('SELECT * FROM system.schema_keyspaces;');
 
 Pool.prototype.monitorConnections = function()
 {
@@ -188,20 +190,50 @@ Pool.prototype.monitorConnections = function()
         {
             var host = dead.pop(),
                 connection = self.createConnection(host);
-            return connection.connect().then(function ()
+            return connection.connect()
+            .then(function ()
             {
+                self.emit('log', 'host rising from the dead: ' + host);
                 self.clients.push(connection);
-            }, function ()
+            })
+            .fail(function ()
             {
-                self.emit('log', 'adding host to dead pool: ' + JSON.stringify(host));
+                self.emit('log', 'host still dead: ' + host);
                 dead.push(host);
                 checkDead();
-            });
+            }).done();
         }
-        self.retryInterval = setTimeout(checkDead, 5000);
+        self.checkDeadTimer = setTimeout(checkDead, 5000);
     }
 
-    this.retryInterval = setTimeout(checkDead, 5000);
+    function ping(client)
+    {
+        var timeout;
+
+        function addToDeadPool()
+        {
+            var deadhost = client.host + ':' + client.port;
+            self.emit('log', 'pushing host onto dead pool: ' + deadhost);
+            self.dead.push(deadhost);
+            if (!self.checkDeadTimer)
+                self.checkDeadTimer = setTimeout(checkDead, 5000);
+        }
+
+        client.executeCQL(Pool.PING_QUERY)
+        .then(function(result)
+        {
+            clearTimeout(timeout);
+        })
+        .fail(function(error)
+        {
+            clearTimeout(timeout);
+            addToDeadPool();
+        }).done();
+    }
+
+    _.each(self.clients, ping);
+    if (self.dead.length)
+        this.checkDeadTimer = setTimeout(checkDead, 5000);
 };
 
 Pool.prototype.close = function()
@@ -211,7 +243,8 @@ Pool.prototype.close = function()
         self = this;
 
     this.closing = true;
-    clearTimeout(this.retryInterval);
+    clearTimeout(this.checkDeadTimer);
+    clearInterval(this.monitorInterval);
 
     if (!pendingClients)
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":        "scamandrios",
-    "version":     "0.2.0",
+    "version":     "0.2.1",
     "description": "node.js bindings for Cassandra with a promises API",
     "keywords":
     [


### PR DESCRIPTION
A connection pool monitor timer fires every 15 seconds & exercises each active client with a query against the system keyspace. If this query responds with an error or times out, the client is removed from the active pool & added to the dead pool. The dead pool is re-checked every time the monitor function executes, so cassandra nodes that die & revive can be re-added to the pool.

Previously there was no way to detect or remove dead nodes from the pool, so it would cheerfully go on handing out dead clients to any users.

While I was there, cleaned up connection pool to use foo.prototype.bar = function() syntax, which is more common in our code base.

Also, the connection pool object now emits `log` events that clients can either listen for & log as they please or allow to drop on the floor.
