### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The first argument to `cql()` is the query string. The second is an array of ite
 
 ### CQL3 queries
 
-CQL can express a set of types more specific than javascript's types. To javascript, a Cassandra `set<text>` and a `list<text>` both look like arrays. We found it helpful to have a query-contruction API that accepted type hints, so sets and lists could be interpolated properly into query strings.
+CQL can express a set of types more specific than javascript's types. To javascript, a Cassandra `set<text>` and a `list<text>` both look like arrays. We found it helpful to have a query-construction API that accepted type hints, so sets and lists could be interpolated properly into query strings.
 
 The `scamandrios.Query` constructor exists to help you do this. Here's a somewhat contrived example:
 


### PR DESCRIPTION
@lyveminds, I've corrected a typographical error in the documentation of the [scamandrios](https://github.com/lyveminds/scamandrios) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
